### PR TITLE
Reset contents of platform.properties

### DIFF
--- a/config-template/platform.properties
+++ b/config-template/platform.properties
@@ -1,38 +1,17 @@
-#!/bin/sh
-#
-# Copyright 2015 Delft University of Technology
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# The platform
+platform.name = Powergraph
+platform.acronym = pgraph
+platform.version = ?
+platform.link = ?
 
-# Adapt this build script to your cluster environment.
+# Home directory where PowerGraph has been installed
+platform.powergraph.home =
 
-# Download Powergraph v2.2 #a038f97
-wget https://github.com/dato-code/PowerGraph
+# Whether to run PowerGraph with or without MPI
+platform.powergraph.disable_mpi = false
 
-# Change boost src to http://kent.dl.sourceforge.net/project/boost/boost/1.53.0/boost_1_53_0.tar.gz in CMakeList.
+# Set the command to run for PowerGraph
+platform.powergraph.command = %s %s
 
-# Adapt compilation setup
-rm -rf deps/*
-./configure --no_jvm
-
-# Load compilers
-module unload intel-mpi
-module unload gcc
-module load openmpi/open64/64/1.10.1
-module load openmpi/gcc/64/1.10.1
-module list
-
-# Compile Distribution
-cd release
-make
+# Set the number of threads to run (leave blank to use default number of threads)
+#platform.powergraph.num-threads =


### PR DESCRIPTION
`platform.properties` wrongfully had the contents of the compile script in it. This PR should reset that to what it was before.